### PR TITLE
Refactor for unit test friendliness

### DIFF
--- a/app/src/config.py
+++ b/app/src/config.py
@@ -1,0 +1,27 @@
+from dataclasses import dataclass
+from dotenv import load_dotenv
+import os
+
+@dataclass
+class Config:
+    pvue_url: str
+    username: str
+    password: str
+    data_output_format: str = "json"
+    grades_file_name: str = "grades"
+    output_dir: str = "."
+
+def load_config(env_file: str | None = None) -> "Config":
+    """Load configuration from environment variables or an optional dotenv file."""
+    if env_file:
+        load_dotenv(env_file)
+    else:
+        load_dotenv(verbose=True)
+    return Config(
+        pvue_url=os.environ.get("PVUE_URL", ""),
+        username=os.environ.get("PVUE_USERNAME", ""),
+        password=os.environ.get("PVUE_PASS", ""),
+        data_output_format=os.environ.get("DATA_OUTPUT_FORMAT", "json"),
+        grades_file_name=os.environ.get("GRADES_FILE_NAME", "grades"),
+        output_dir=os.environ.get("OUTPUT_DIR", "."),
+    )

--- a/app/src/main.py
+++ b/app/src/main.py
@@ -1,37 +1,26 @@
-
 import os
 
-from dotenv import load_dotenv
-
+from config import Config, load_config
 from scrappers.pvue_login import login_to_website
 from scrappers.scrape_grades import process_grades
 from scrappers.scrape_assignments import process_assignments
 
-# Load environment variables
-load_dotenv(verbose=True)
 
+def main(config: Config | None = None) -> None:
+    """Entry point for scraping ParentVUE."""
 
+    cfg = config or load_config()
 
-def main():
-
-    url = os.getenv("PVUE_URL")
-    user = os.getenv("PVUE_USERNAME")
-    pwd = os.getenv("PVUE_PASS")
-
-    s_driver = None
-
+    driver = None
     try:
-        data_output_format = os.environ.get("DATA_OUTPUT_FORMAT")
-
-        s_driver = login_to_website(url,user,pwd)
-        #process_grades(s_driver, data_output_format)
-        process_assignments(s_driver, data_output_format)
-
-    except Exception as e:
-        print(e)
+        driver = login_to_website(cfg.pvue_url, cfg.username, cfg.password)
+        # process_grades(driver, cfg.data_output_format, cfg.grades_file_name, cfg.output_dir)
+        process_assignments(driver, cfg.data_output_format, output_dir=cfg.output_dir)
+    except Exception as exc:
+        print(exc)
     finally:
-        if s_driver:
-            s_driver.quit()
+        if driver:
+            driver.quit()
 
 
 if __name__ == "__main__":

--- a/app/src/scrappers/scrape_grades.py
+++ b/app/src/scrappers/scrape_grades.py
@@ -88,15 +88,26 @@ def __scrape_grades(driver):
     return data
 
 
-def __save_grades(grade_json, data_output_format):
-    file_utils.save_data(grade_json, __date_scraped, data_output_format)
+def __save_grades(grade_json, data_output_format, filename: str, output_dir: str):
+    file_utils.save_data(
+        grade_json,
+        __date_scraped,
+        data_output_format,
+        filename=filename,
+        directory=output_dir,
+    )
 
 
 def __convert_to_csv(grade_json):
     return csv_utils.json_to_csv_pandas(grade_json)
 
 
-def process_grades(driver, data_output_format):
+def process_grades(
+    driver,
+    data_output_format: str,
+    filename: str = "grades",
+    output_dir: str = ".",
+) -> list[dict[str, str]]:
 
     try:
 
@@ -104,7 +115,11 @@ def process_grades(driver, data_output_format):
 
         grade_json = __scrape_grades(driver)
 
-        __save_grades(grade_json, data_output_format)
+        __save_grades(grade_json, data_output_format, filename, output_dir)
+
+        return grade_json
 
     except Exception as e:
-        print(f"[ERROR] Failed to save JSON: {e}")
+        print(f"[ERROR] Failed to save grades: {e}")
+        return []
+

--- a/app/src/utils/csv_utils.py
+++ b/app/src/utils/csv_utils.py
@@ -1,5 +1,7 @@
+import os
+from typing import Any, Dict, List
+
 import pandas as pd
-from typing import List, Dict, Any
 from utils.file_utils import get_all_files_in_output_dir
 
 def json_to_csv_pandas(json_data: List[Dict[str, Any]]) -> str | None:
@@ -13,32 +15,27 @@ def json_to_csv_pandas(json_data: List[Dict[str, Any]]) -> str | None:
         None (prints CSV output)
     """
     if not json_data:
-        print("[ERROR] No data provided to convert.")
         return None
 
     # Convert to pandas DataFrame
     df = pd.DataFrame(json_data)
 
     try:
-        # Save to CSV with proper formatting
         csv_output = df.to_csv(index=False, encoding="utf-8", quoting=1)
         return csv_output
-    except Exception as e:
-        print(f"[ERROR] Failed to convert JSON to CSV: {e}")
+    except Exception:
         return None
 
 
-def merge_csv_data_by_scrape_date():
+def merge_csv_data_by_scrape_date(output_dir: str, output_name: str = "merged.csv") -> pd.DataFrame:
+    """Merge all CSV files in ``output_dir`` into a single DataFrame."""
 
-    csv_files, output_file = get_all_files_in_output_dir("csv")
-
-    # Load all CSVs into a list of dataframes
+    csv_files = get_all_files_in_output_dir("csv", output_dir)
     dfs = [pd.read_csv(file) for file in csv_files]
 
-    # Concatenate all dataframes into one
     merged_df = pd.concat(dfs, ignore_index=True)
 
-    # Save the merged CSV file
+    output_file = os.path.join(output_dir, output_name)
     merged_df.to_csv(output_file, index=False)
 
     return merged_df


### PR DESCRIPTION
## Summary
- add `Config` dataclass for loading runtime configuration
- refactor file utilities to return paths and accept parameters
- update CSV utilities to use refactored helpers
- change grade and assignment scraping functions to return data
- main now uses loaded configuration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f6291388483279ef9c122a3561469